### PR TITLE
make sure to open the lexicon as UTF-8

### DIFF
--- a/vaderSentiment/vaderSentiment.py
+++ b/vaderSentiment/vaderSentiment.py
@@ -195,7 +195,7 @@ class SentimentIntensityAnalyzer(object):
     def __init__(self, lexicon_file="vader_lexicon.txt"):
         _this_module_file_path_ = abspath(getsourcefile(lambda:0))
         lexicon_full_filepath = join(dirname(_this_module_file_path_), lexicon_file)
-        with open(lexicon_full_filepath) as f:
+        with open(lexicon_full_filepath, encoding='utf-8') as f:
             self.lexicon_full_filepath = f.read()
         self.lexicon = self.make_lex_dict()
 


### PR DESCRIPTION
we fail in environments were LANG is not set to UTF-8. This fixes the issue by forcing to read the lexicon as UTF-8 (which coincides with its encoding).