### PR TITLE
Fix Issue with scoring on duplicate word in a sentence 

### DIFF
--- a/vaderSentiment/vaderSentiment.py
+++ b/vaderSentiment/vaderSentiment.py
@@ -220,9 +220,8 @@ class SentimentIntensityAnalyzer(object):
 
         sentiments = []
         words_and_emoticons = sentitext.words_and_emoticons
-        for item in words_and_emoticons:
+        for i, item in enumerate(words_and_emoticons):
             valence = 0
-            i = words_and_emoticons.index(item)
             if (i < len(words_and_emoticons) - 1 and item.lower() == "kind" and \
                 words_and_emoticons[i+1].lower() == "of") or \
                 item.lower() in BOOSTER_DICT:


### PR DESCRIPTION
considering the following two text:

```
there is a good which actually is good
```

and 

```
there is a good which actually is least good
```

both of them are computed with the same result because `least` is not considered as expected. 