### PR TITLE
add install_requires in setup.py for dependency(requests)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
   #packages = ['vaderSentiment'], # this must be the same as the name above
   packages = find_packages(exclude=['tests*']), # a better way to do it than the line above -- this way no typo/transpo errors
   include_package_data=True,
+  install_requires=['requests'],
   version = '3.2.1',
   description = 'VADER Sentiment Analysis. VADER (Valence Aware Dictionary and sEntiment Reasoner) is a lexicon and rule-based sentiment analysis tool that is specifically attuned to sentiments expressed in social media, and works well on texts from other domains.',
   long_description = read("README.rst"),


### PR DESCRIPTION
**requests** module imported [line 17](https://github.com/cjhutto/vaderSentiment/blob/master/vaderSentiment/vaderSentiment.py#L17) and used in [this line](https://github.com/cjhutto/vaderSentiment/blob/master/vaderSentiment/vaderSentiment.py#L672) for demo, but missed in package dependency.

this module is not used in sentiment analysis, but I can't import vaderSentiment because of line 17.